### PR TITLE
fix(automation): recover from and surface low-information fallback guard failures

### DIFF
--- a/.github/workflows/author-digest-pr.yml
+++ b/.github/workflows/author-digest-pr.yml
@@ -247,7 +247,7 @@ jobs:
               `1. \`data/events/${dateKey}.json\` を読み、重要な更新を把握する`,
               `2. \`summaries/daily/${dateKey}.md\` の \`注目トピック\` と \`テーマ別まとめ\` を更新する`,
               '3. 今週分・隔週分のドラフト対象期間に含まれる場合は、`drafts/**` の要点または本文を更新する',
-              '4. `reporting.mjs` に未登録のタイトルや要約パターンが必要なら追加する',
+              '4. `reporting.mjs` に未登録のタイトルや要約パターンがあれば追加する。低情報 fallback が残る場合は、該当タイトルの具体要約を `exactSummaryMappings` / `exactImportanceMappings`（VS Code release note は `vscodeReleaseSummaries`）へ追加して解消する。`data/**` は編集しない',
               ...(hasPagesBuildFailure
                 ? ['4.5. `npm run build:pages` を再現し、Pages build failure の原因を解消する']
                 : []),
@@ -268,7 +268,7 @@ jobs:
               ...(hasPagesBuildFailure
                 ? ['- Pages build repair の場合だけ `scripts/build-pages.mjs` も変更可']
                 : []),
-              '- `npm run collect` と `npm run build:pages` が通る状態を維持する',
+              '- `npm test`（low-information fallback ガード）, `npm run collect`, `npm run build:pages` が通る状態を維持する',
               '- 不確実な場合は `needs-human-review` を明記して PR を作る',
               '',
               '### 依頼スコープ',

--- a/.github/workflows/self-heal-generated-pr.yml
+++ b/.github/workflows/self-heal-generated-pr.yml
@@ -217,6 +217,19 @@ jobs:
               );
             }
 
+            if (failedSteps.includes('Validate low-information fallback guard')) {
+              feedbackLines.push(
+                '### low-information fallback ガードエラー',
+                '- このステップは `npm test` です。`data/events/*.json` と `summaries/daily/*.md` に低情報 fallback 文言が残っていると失敗します',
+                '- 失敗ログに `<file> contains low-information fallback copy` と出ます。その `<file>` が原因のイベント源です',
+                '- `data/**` は読み取り専用です。生データは編集しないでください',
+                '- 該当タイトルの具体要約を `scripts/lib/reporting.mjs` の `exactSummaryMappings` / `exactImportanceMappings`（VS Code release note は `vscodeReleaseSummaries`）へ追加して fallback を解消してください',
+                '- 追加する要約には対象更新の「何が変わったか」と「運用上なぜ気にするか」を含め、元ソースにない数値や固有名詞を足さないでください',
+                '- 修正後に `npm test` がローカルで通ることを確認してから push してください',
+                '',
+              );
+            }
+
             if (failedSteps.includes('Validate collect command')) {
               feedbackLines.push(
                 '### collect エラー',

--- a/scripts/collect.mjs
+++ b/scripts/collect.mjs
@@ -13,6 +13,7 @@ import {
   localizedImportanceLabel,
   localizedSummary,
   localizedTitle,
+  lowInformationFallbackMarkers,
   originalTitle,
   summarizeEventSet,
 } from "./lib/reporting.mjs";
@@ -1063,6 +1064,48 @@ async function main() {
   console.log(`Latest run metadata written to ${eventFile}.`);
   if (errors.length > 0) {
     console.warn(`Encountered ${errors.length} error(s).`);
+  }
+
+  reportLowInformationFallbacks(allLogs);
+}
+
+function reportLowInformationFallbacks(allLogs) {
+  const fallbackReport = allLogs
+    .map((log) => {
+      const digest = buildDailyDigest(log);
+      const generatedText = [
+        summarizeEventSet(digest.uniqueEvents, "ja", {
+          maxLength: 960,
+          maxHighlights: 5,
+        }),
+        ...digest.uniqueEvents.flatMap((event) => [
+          localizedSummary(event),
+          importanceReason(event),
+        ]),
+      ].join("\n");
+      const markers = lowInformationFallbackMarkers.filter((marker) =>
+        generatedText.includes(marker),
+      );
+      return { date: log.date, markers };
+    })
+    .filter((entry) => entry.markers.length > 0);
+
+  if (fallbackReport.length === 0) {
+    return;
+  }
+
+  const totalMarkers = fallbackReport.reduce(
+    (sum, entry) => sum + entry.markers.length,
+    0,
+  );
+  console.warn(
+    `Low-information fallback copy detected in ${fallbackReport.length} day(s) (${totalMarkers} marker hit(s)). ` +
+      "Add a specific summary for the offending titles to scripts/lib/reporting.mjs " +
+      "(exactSummaryMappings / exactImportanceMappings / vscodeReleaseSummaries) so the npm test fallback guard stays green. " +
+      "Do not edit data/** to resolve this.",
+  );
+  for (const entry of fallbackReport) {
+    console.warn(`- ${entry.date}: ${entry.markers.length} fallback marker(s)`);
   }
 }
 


### PR DESCRIPTION
## 背景

Issue #162 から自動生成された PR #163 は `Validate low-information fallback guard`（実体は `npm test`）に 3 回連続で失敗し、`needs-human-review` を付けて close されました。

根本原因: `self-heal-generated-pr.yml` のフィードバック生成には多くの失敗ステップ用ハンドラがある一方で、**`Validate low-information fallback guard` 用のハンドラが存在せず**、このガードが落ちると汎用文言しか返らないため、cloud agent が自力で修復できませんでした。実際の失敗は `data/events/2026-06-02.json contains low-information fallback copy` で、`data/**` は編集禁止のため、正しい修復は `scripts/lib/reporting.mjs` に該当タイトルの具体要約マッピングを追加することでした。

## 変更内容

AGENTS のガードレール（validation / self-heal feedback / authoring 指示を揃える）に従い、再発防止を二段構えで実装:

**1. 再発時に自動回復しやすくする**
- **self-heal-generated-pr.yml**: `Validate low-information fallback guard` 失敗用のフィードバック分岐を追加。原因の `data/events/*.json` を特定し、`data/**` を触らず `reporting.mjs`（`exactSummaryMappings` / `exactImportanceMappings` / `vscodeReleaseSummaries`）へ具体要約を追加して解消するよう具体的に案内し、`npm test` での検証を促す。
- **author-digest-pr.yml**: authoring issue の手順 4 と制約を更新し、低情報 fallback の解消手順と `npm test` の維持を最初から明示。

**2. 発生を早期に可視化する**
- **scripts/collect.mjs**: `npm run collect`（CI で毎日実行）の最後に、低情報 fallback copy が残っている日付を警告出力。`reporting.mjs` のマッピング追加を促し、`data/**` は読み取り専用のまま。検出ロジックは `lowInformationFallbackMarkers` を使い `npm test` ガードと完全一致するため、collect を失敗させない純粋な警告。

## 検証

- `npm test`（fallback ガード）✅ パス
- `npm run collect` ✅ 実行成功（0 new events、誤検知の警告なし）。生成された `data/**`・`summaries/**` の差分は guardrail に従い復元済み
- 両 workflow YAML を `yaml.safe_load` でパース確認 ✅

実行ロジックの挙動は変えず、エージェントへの指示精度と早期可視化のみ改善しています。