### PR TITLE
fix: repair stalled digest automation

### DIFF
--- a/.github/workflows/author-digest-pr.yml
+++ b/.github/workflows/author-digest-pr.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   author-request:
-    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.name == 'Collect updates' && github.event.workflow_run.conclusion == 'success') || (github.event.workflow_run.name == 'Deploy GitHub Pages' && github.event.workflow_run.conclusion == 'failure')
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.name == 'Collect updates' && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')) || (github.event.workflow_run.name == 'Deploy GitHub Pages' && github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
 
     steps:
@@ -75,10 +75,11 @@ jobs:
               : 0;
             let failedStepNames = [];
             let hasPagesBuildFailure = false;
+            let hasCollectUpdatesFailure = false;
+            let hasKnownCollectFailure = false;
 
             if (
               context.eventName === 'workflow_run' &&
-              workflowName === 'Deploy GitHub Pages' &&
               workflowConclusion === 'failure' &&
               workflowRunId > 0
             ) {
@@ -94,7 +95,15 @@ jobs:
                   .filter((step) => step.conclusion === 'failure')
                   .map((step) => step.name),
               );
-              hasPagesBuildFailure = failedStepNames.includes('Build Pages site');
+              hasPagesBuildFailure =
+                workflowName === 'Deploy GitHub Pages' &&
+                failedStepNames.includes('Build Pages site');
+              hasCollectUpdatesFailure = workflowName === 'Collect updates';
+              hasKnownCollectFailure =
+                hasCollectUpdatesFailure &&
+                failedStepNames.some((step) =>
+                  ['Collect updates', 'Validate collected output'].includes(step),
+                );
             }
 
             if (files.length === 0) {
@@ -163,8 +172,16 @@ jobs:
             const fallbackEntry = fallbackSummaryHits.find((entry) => entry.dateKey === dateKey);
             const fallbackMatches = fallbackEntry?.matches ?? [];
             const hasLowInformationSummary = fallbackMatches.length > 0;
-            const shouldAuthor = newEventsCount > 0 || forceIssue || hasLowInformationSummary || hasPagesBuildFailure;
-            const allowAutomationResume = isManual || hasPagesBuildFailure;
+            const shouldAuthor =
+              newEventsCount > 0 ||
+              forceIssue ||
+              hasLowInformationSummary ||
+              hasPagesBuildFailure ||
+              hasCollectUpdatesFailure;
+            const requiresHumanReview =
+              hasCollectUpdatesFailure && !hasKnownCollectFailure;
+            const allowAutomationResume =
+              isManual || hasPagesBuildFailure || hasKnownCollectFailure;
 
             if (!shouldAuthor) {
               core.info(`No reader-facing new events or low-information fallback detected for ${selectedFile}.`);
@@ -180,6 +197,15 @@ jobs:
             }
             if (hasPagesBuildFailure) {
               triggerReasons.push('Deploy GitHub Pages の Build Pages site が失敗');
+            }
+            if (hasKnownCollectFailure) {
+              triggerReasons.push(
+                `Collect updates の既知の失敗（${failedStepNames.join(', ')}）`,
+              );
+            } else if (hasCollectUpdatesFailure) {
+              triggerReasons.push(
+                `Collect updates の未分類の失敗（${failedStepNames.join(', ') || 'unknown step'}）`,
+              );
             }
             if (newEventsCount > 0) {
               triggerReasons.push(`最新 run で読者向け新規更新を ${newEventsCount} 件検知`);
@@ -201,7 +227,12 @@ jobs:
               full: 'summaries/daily と drafts 全体と reporting.mjs',
             };
             const requestedScopeLabel = scopeLabelMap[requestedScope] ?? scopeLabelMap.full;
-            const prTitleRule = hasPagesBuildFailure
+            const collectRepairMarker = hasCollectUpdatesFailure
+              ? `Collect updates repair for run ${workflowRunId}`
+              : '';
+            const prTitleRule = hasKnownCollectFailure
+              ? 'fix: repair collect updates'
+              : hasPagesBuildFailure
               ? `docs: update digest ${dateKey} + pages`
               : `docs: update digest ${dateKey}`;
             const pagesRepairMarker = hasPagesBuildFailure
@@ -232,6 +263,15 @@ jobs:
                     `- failed run: ${context.payload.workflow_run?.html_url || 'n/a'}`,
                   ]
                 : []),
+              ...(hasCollectUpdatesFailure
+                ? [
+                  `- failed steps: ${failedStepNames.join(', ') || 'unknown step'}`,
+                  `- failed run: ${context.payload.workflow_run?.html_url || 'n/a'}`,
+                  hasKnownCollectFailure
+                    ? '- 既知の collector / data-quality failure のため、限定された修復 PR を作成してください。'
+                    : '- 未分類の失敗です。自動修復は開始せず、needs-human-review で原因を確認してください。',
+                ]
+                : []),
               ...(hasLowInformationSummary
                 ? fallbackMatches.map((marker) => `- fallback: ${marker}`)
                 : []),
@@ -255,6 +295,11 @@ jobs:
               ...(hasPagesBuildFailure
                 ? ['4.5. `npm run build:pages` を再現し、Pages build failure の原因を解消する']
                 : []),
+              ...(hasKnownCollectFailure
+                ? [
+                  '4.6. `npm run collect` と `npm run test:data` を再現し、低情報 fallback を削除せず、保存前に公開不能なイベントを除外するなど根本原因を直す',
+                ]
+                : []),
               '5. 変更を 1 つの PR として作成する',
               '',
               '### 文章ルール',
@@ -272,6 +317,12 @@ jobs:
               ...(hasPagesBuildFailure
                 ? ['- Pages build repair の場合だけ `scripts/build-pages.mjs` も変更可']
                 : []),
+              ...(hasKnownCollectFailure
+                ? [
+                  '- Collect updates repair の場合だけ `scripts/collect.mjs`, `scripts/lib/reporting.mjs`, `config/sources.json`, `tests/reporting-low-information.test.mjs`, `tests/sources.test.mjs` を変更可',
+                  '- `data/**` を書き換えず、低情報 validation を削除または弱めない',
+                ]
+                : []),
               '- `npm run collect` と `npm run build:pages` が通る状態を維持する',
               '- 不確実な場合は `needs-human-review` を明記して PR を作る',
               '',
@@ -284,6 +335,9 @@ jobs:
               ...(hasPagesBuildFailure
                 ? [`- \`scripts/build-pages.mjs\` を変更する場合、PR 本文に \`${pagesRepairMarker}\` を含める`]
                 : []),
+              ...(hasCollectUpdatesFailure
+                ? [`- PR 本文に \`${collectRepairMarker}\` を含める`]
+                : []),
               '- 根拠が弱い場合や許可外変更が必要な場合は `needs-human-review` を付けて止める',
               '',
               '### 直近の候補',
@@ -293,9 +347,18 @@ jobs:
             core.setOutput('should_run', 'true');
             core.setOutput('date_key', dateKey);
             core.setOutput('pr_title_rule', prTitleRule);
-            core.setOutput('issue_title', `Digest authoring request: ${dateKey}`);
+            core.setOutput(
+              'issue_title',
+              hasCollectUpdatesFailure
+                ? `Collect updates repair: ${workflowRunId}`
+                : `Digest authoring request: ${dateKey}`,
+            );
             core.setOutput('issue_body', body);
             core.setOutput('allow_automation_resume', allowAutomationResume ? 'true' : 'false');
+            core.setOutput(
+              'requires_human_review',
+              requiresHumanReview ? 'true' : 'false',
+            );
 
       - name: Close stale authoring issue when no work remains
         if: steps.target.outputs.should_run != 'true' && steps.target.outputs.issue_title != ''
@@ -372,6 +435,7 @@ jobs:
             const labels = ['copilot', 'digest-authoring', 'auto-pr'];
             const copilotLogins = new Set(['Copilot', 'copilot-swe-agent']);
             const allowAutomationResume = process.env.ALLOW_AUTOMATION_RESUME === 'true';
+            const requiresHumanReview = process.env.REQUIRES_HUMAN_REVIEW === 'true';
             const dateKeyMatch = title.match(/(\d{4}-\d{2}-\d{2})/);
             const dateKey = dateKeyMatch ? dateKeyMatch[1] : '';
             const assignmentInstructions = [
@@ -438,9 +502,11 @@ jobs:
               currentLabels.has('needs-human-review') &&
               allowAutomationResume &&
               !existingGeneratedPr;
-            const isHumanReviewBlocked = currentLabels.has('needs-human-review') && !canResumeAutomation;
+            const isHumanReviewBlocked =
+              requiresHumanReview ||
+              (currentLabels.has('needs-human-review') && !canResumeAutomation);
 
-            if (!createdNewIssue || canResumeAutomation) {
+            if (!createdNewIssue || canResumeAutomation || requiresHumanReview) {
               await github.rest.issues.setLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -592,6 +658,7 @@ jobs:
           ISSUE_TITLE: ${{ steps.target.outputs.issue_title }}
           ISSUE_BODY: ${{ steps.target.outputs.issue_body }}
           ALLOW_AUTOMATION_RESUME: ${{ steps.target.outputs.allow_automation_resume }}
+          REQUIRES_HUMAN_REVIEW: ${{ steps.target.outputs.requires_human_review }}
 
       - name: Shepherd generated PR
         if: steps.target.outputs.should_run == 'true' && steps.create_or_update_authoring_issue.outputs.automation_state == 'active'

--- a/.github/workflows/auto-merge-generated-pr.yml
+++ b/.github/workflows/auto-merge-generated-pr.yml
@@ -39,6 +39,7 @@ jobs:
             const titlePattern = /^docs: update digest \d{4}-\d{2}-\d{2}(?: \+ (?:drafts|reporting|pages)){0,3}$/;
             const bodyPattern = /Generated from `?data\/events\/\d{4}-\d{2}-\d{2}\.json`?/;
             const pagesRepairPattern = /Pages build repair for run \d+/;
+            const collectRepairPattern = /Collect updates repair for run \d+/;
             const summaryDatePattern = /^summaries\/daily\/(\d{4}-\d{2}-\d{2})\.md$/;
 
             function isCopilotDraftPlan(currentPr) {
@@ -153,13 +154,20 @@ jobs:
             }
 
             const isPagesBuildRepair = /\+ pages$/.test(pr.title || '') && pagesRepairPattern.test(pr.body || '');
+            const isCollectUpdatesRepair = collectRepairPattern.test(pr.body || '');
             const blocked = files
               .map((file) => file.filename)
               .filter((file) =>
                 !/^summaries\/daily\//.test(file) &&
                 !/^drafts\//.test(file) &&
                 file !== 'scripts/lib/reporting.mjs' &&
-                !(isPagesBuildRepair && file === 'scripts/build-pages.mjs')
+                !(isPagesBuildRepair && file === 'scripts/build-pages.mjs') &&
+                !(isCollectUpdatesRepair && [
+                  'scripts/collect.mjs',
+                  'config/sources.json',
+                  'tests/reporting-low-information.test.mjs',
+                  'tests/sources.test.mjs',
+                ].includes(file))
               );
 
             const hasInferableSource =
@@ -169,6 +177,13 @@ jobs:
 
             if (blocked.length > 0) {
               await markForHumanReview(`PR #${pr.number} changed disallowed files: ${blocked.join(', ')}`);
+              return;
+            }
+
+            if (isCollectUpdatesRepair) {
+              await markForHumanReview(
+                `PR #${pr.number} repairs the collection pipeline and requires human review before merge.`,
+              );
               return;
             }
 

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -41,6 +41,7 @@ jobs:
             }
 
             const sourceMarkerPattern = /Generated from `?data\/events\/(\d{4}-\d{2}-\d{2})\.json`?/;
+            const collectRepairPattern = /Collect updates repair for run \d+/;
 
             function resolveDateKey(pr, files) {
               const summaryFile = files
@@ -84,8 +85,17 @@ jobs:
             });
             const pr = pull.data;
             const dateKey = resolveDateKey(pr, files);
+            const isCollectUpdatesRepair = collectRepairPattern.test(pr.body || '');
 
-            if (!dateKey) {
+            if (isCollectUpdatesRepair) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['needs-human-review'],
+              });
+              core.info(`Preserving bounded collect repair metadata for PR #${issueNumber}.`);
+            } else if (!dateKey) {
               core.warning('Could not infer a date key for generated PR metadata normalization.');
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,

--- a/.github/workflows/self-heal-generated-pr.yml
+++ b/.github/workflows/self-heal-generated-pr.yml
@@ -179,6 +179,18 @@ jobs:
               '',
             ];
 
+            const isCollectUpdatesRepair = /Collect updates repair for run \d+/.test(pr.body || '');
+            if (isCollectUpdatesRepair) {
+              feedbackLines.push(
+                '### Collect updates repair の検証エラー',
+                '- `data/**` を変更せず、低情報 fallback guard を削除または弱めないでください',
+                '- 許可される修復範囲は `scripts/collect.mjs`, `scripts/lib/reporting.mjs`, `config/sources.json`, 関連テストです',
+                '- `npm run collect`、`npm run test:data`、`npm run build:pages` を再現し、既知の collector / data-quality failure だけを修正してください',
+                '- この種の PR は意図的に auto-merge されず、人による review が必要です',
+                '',
+              );
+            }
+
             if (failedSteps.includes('Validate Markdown structure')) {
               feedbackLines.push(
                 '### Markdown 構造エラー',

--- a/.github/workflows/validate-generated-pr.yml
+++ b/.github/workflows/validate-generated-pr.yml
@@ -98,9 +98,18 @@ jobs:
             process.exit(0);
           }
           const isPagesBuildRepair = /\+ pages$/.test(title) && /Pages build repair for run \d+/.test(body);
+          const isCollectUpdatesRepair = /Collect updates repair for run \d+/.test(body);
           const allowed = [/^summaries\/daily\//, /^drafts\//, /^scripts\/lib\/reporting\.mjs$/];
           if (isPagesBuildRepair) {
             allowed.push(/^scripts\/build-pages\.mjs$/);
+          }
+          if (isCollectUpdatesRepair) {
+            allowed.push(
+              /^scripts\/collect\.mjs$/,
+              /^config\/sources\.json$/,
+              /^tests\/reporting-low-information\.test\.mjs$/,
+              /^tests\/sources\.test\.mjs$/,
+            );
           }
           const blocked = changed.filter((file) => !allowed.some((pattern) => pattern.test(file)));
           if (blocked.length > 0) {
@@ -130,12 +139,15 @@ jobs:
           const copilotWipTitlePattern = /^\[WIP\] .*?(?:\d{4}-\d{2}-\d{2}|[A-Z][a-z]+ \d{1,2}, \d{4})$/;
           const bodyPattern = /Generated from `?data\/events\/\d{4}-\d{2}-\d{2}\.json`?/;
           const pagesRepairPattern = /Pages build repair for run \d+/;
+          const collectRepairPattern = /Collect updates repair for run \d+/;
           const summaryDatePattern = /^summaries\/daily\/(\d{4}-\d{2}-\d{2})\.md$/;
           const changesBuildPages = changed.includes('scripts/build-pages.mjs');
+          const isCollectUpdatesRepair = collectRepairPattern.test(body);
           const hasInferableSource =
             bodyPattern.test(body) ||
             changed.some((file) => summaryDatePattern.test(file)) ||
-            titlePattern.test(title);
+            titlePattern.test(title) ||
+            isCollectUpdatesRepair;
           const isPendingNormalization =
             authoringRequestTitlePattern.test(title) ||
             copilotWipTitlePattern.test(title);
@@ -152,6 +164,10 @@ jobs:
 
           if (changesBuildPages && (!/\+ pages$/.test(title) || !pagesRepairPattern.test(body))) {
             console.error('PRs that change scripts/build-pages.mjs must use the + pages title suffix and include the Pages build repair marker in the body.');
+            process.exit(1);
+          }
+          if (isCollectUpdatesRepair && title !== 'fix: repair collect updates') {
+            console.error('Collect updates repair PRs must use the title: fix: repair collect updates.');
             process.exit(1);
           }
           NODE

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -16,6 +16,7 @@
 
 - [collect-updates.yml](../.github/workflows/collect-updates.yml) は毎日 06:30 / 14:30 / 22:30 JST 目安で実行する。GitHub Actions の schedule は高負荷時に遅延しうる
 - Node.js 22 で `npm ci` と `npm run collect` を実行し、[data/events](../data/events) を毎日更新する。[summaries/daily](../summaries/daily) は公開済み更新または未来日付項目がある日だけ生成する
+- 収集結果が reader-facing の低情報 fallback になる場合は、collector が保存前に除外し、`latestRun.skippedLowInformationEvents` に根拠を記録する。低情報 guard 自体は残るため、公開カードには定型文を出さない
 - 変更がなければ commit せず終了する
 - 変更があった場合は `github-actions[bot]` が `data/**` と `summaries/**` を commit / push する
 - collect の最後に [deploy-pages.yml](../.github/workflows/deploy-pages.yml) を dispatch して、push 起点 workflow の非連鎖を補う
@@ -57,6 +58,8 @@
 - `needs-human-review` が付いた PR は意図的に自動 merge しない
 - Cloud agent の `Require approval for workflow runs` が ON でも、Copilot 由来の blocked run は定期 workflow が検出して 1 回だけ rerun して先へ進める
 - それでも PR が出ない場合は、Issue 右サイドバーで Copilot assignee が付いているかと GitHub 側キューを確認する
+- `Collect updates` が `Collect updates` または `Validate collected output` で失敗すると、`author-digest-pr.yml` が既存の Copilot assignment 経路で traceable な `Collect updates repair` Issue / PR を作る。許可範囲は collector、reporting、source selector、関連テストに限定し、`data/**` と低情報 guard は変更不可。修復 PR は必ず `needs-human-review` とし、main へ自動 merge しない
+- Collect failure が上記以外の step の場合も Issue は残すが、Copilot の自動修復は開始せず `needs-human-review` へエスカレーションする。これにより未分類の失敗を成功扱いにしない
 
 ## Workflow 一覧
 

--- a/scripts/collect.mjs
+++ b/scripts/collect.mjs
@@ -14,6 +14,7 @@ import {
   localizedSummary,
   localizedTitle,
   originalTitle,
+  partitionLowInformationEvents,
   summarizeEventSet,
 } from "./lib/reporting.mjs";
 import { normalizeSnapshotLine } from "./lib/snapshot-text.mjs";
@@ -1080,8 +1081,24 @@ async function main() {
     (left, right) => safeDate(right.publishedAt) - safeDate(left.publishedAt),
   );
   const collectionTime = new Date();
-  const filteredMergedEvents = applyEditorialPolicy(normalizedMergedEvents);
-  const publishedEvents = filteredMergedEvents.filter(
+  const editorialEvents = applyEditorialPolicy(normalizedMergedEvents);
+  const { acceptedEvents, rejectedEvents } =
+    partitionLowInformationEvents(editorialEvents);
+  const acceptedEventIds = new Set(
+    acceptedEvents.map((event) => event.eventId),
+  );
+  const acceptedNewEvents = events.filter((event) =>
+    acceptedEventIds.has(event.eventId),
+  );
+  const skippedLowInformationEvents = rejectedEvents.map(
+    ({ event, fallbackMarkers }) => ({
+      eventId: event.eventId,
+      sourceId: event.sourceId,
+      title: event.title,
+      fallbackMarkers,
+    }),
+  );
+  const publishedEvents = acceptedEvents.filter(
     (event) =>
       !event.isFutureDated &&
       safeDate(event.publishedAt ?? event.detectedAt) <= collectionTime,
@@ -1089,16 +1106,16 @@ async function main() {
 
   const latestRun = {
     generatedAt: new Date().toISOString(),
-    newEventsCount: events.length,
-    newEventIds: events.map((event) => event.eventId),
+    newEventsCount: acceptedNewEvents.length,
+    newEventIds: acceptedNewEvents.map((event) => event.eventId),
     errorCount: errors.length,
+    skippedLowInformationEvents,
   };
-
   const eventLog = {
     date: today,
     generatedAt: latestRun.generatedAt,
     latestRun,
-    events: filteredMergedEvents,
+    events: acceptedEvents,
     errors,
   };
   const allLogs = [...logs.filter((log) => log.date !== today), eventLog].sort(
@@ -1113,6 +1130,11 @@ async function main() {
 
   console.log(`Collected ${events.length} new event(s).`);
   console.log(`Latest run metadata written to ${eventFile}.`);
+  if (skippedLowInformationEvents.length > 0) {
+    console.warn(
+      `Excluded ${skippedLowInformationEvents.length} low-information event(s) before persistence.`,
+    );
+  }
   if (errors.length > 0) {
     console.warn(`Encountered ${errors.length} error(s).`);
   }

--- a/scripts/lib/reporting.mjs
+++ b/scripts/lib/reporting.mjs
@@ -2519,6 +2519,34 @@ export function localizedSummary(event, locale = "ja") {
   );
 }
 
+export function lowInformationFallbacksForEvent(event) {
+  const renderedFields = [
+    localizedSummary(event),
+    importanceReason(event),
+  ];
+
+  return lowInformationFallbackMarkers.filter((marker) =>
+    renderedFields.some((field) => field.includes(marker)),
+  );
+}
+
+export function partitionLowInformationEvents(events) {
+  const acceptedEvents = [];
+  const rejectedEvents = [];
+
+  for (const event of events ?? []) {
+    const fallbackMarkers = lowInformationFallbacksForEvent(event);
+    if (isReaderEvent(event) && fallbackMarkers.length > 0) {
+      rejectedEvents.push({ event, fallbackMarkers });
+      continue;
+    }
+
+    acceptedEvents.push(event);
+  }
+
+  return { acceptedEvents, rejectedEvents };
+}
+
 function digestTopicLabel(topic, locale = "ja") {
   const labels = {
     ja: {

--- a/tests/reporting-low-information.test.mjs
+++ b/tests/reporting-low-information.test.mjs
@@ -10,8 +10,10 @@ import {
   isReaderEvent,
   localizedSummary,
   localizedTitle,
+  lowInformationFallbacksForEvent,
   lowInformationFallbackMarkers,
   originalTitle,
+  partitionLowInformationEvents,
   rankEvent,
   selectEditorialHighlights,
   summarizeEventSet,
@@ -64,6 +66,16 @@ assert.match(
 );
 assert.match(
   authorWorkflowSource,
+  /hasKnownCollectFailure/,
+  "author-digest-pr workflow must classify known collect failures",
+);
+assert.match(
+  authorWorkflowSource,
+  /Collect updates repair for run/,
+  "author-digest-pr workflow must create a traceable collect repair request",
+);
+assert.match(
+  authorWorkflowSource,
   /buildDailyDigest, lowInformationFallbackMarkers/,
   "author-digest-pr workflow must use the shared reader-facing digest classifier",
 );
@@ -97,6 +109,41 @@ assert.match(
   /`data\/\*\*` は生データなので変更しないでください/,
   "self-heal fallback feedback must keep data files read-only",
 );
+assert.match(
+  selfHealWorkflowSource,
+  /Collect updates repair の検証エラー/,
+  "self-heal workflow must preserve collect repair safety boundaries",
+);
+
+const requestReviewWorkflowSource = fs.readFileSync(
+  ".github/workflows/request-copilot-review.yml",
+  "utf8",
+);
+assert.match(
+  requestReviewWorkflowSource,
+  /Preserving bounded collect repair metadata/,
+  "metadata normalization must preserve collect repair PR titles",
+);
+
+const validateGeneratedPrWorkflowSource = fs.readFileSync(
+  ".github/workflows/validate-generated-pr.yml",
+  "utf8",
+);
+assert.match(
+  validateGeneratedPrWorkflowSource,
+  /Collect updates repair for run/,
+  "generated PR validation must recognize the bounded repair marker",
+);
+
+const autoMergeWorkflowSource = fs.readFileSync(
+  ".github/workflows/auto-merge-generated-pr.yml",
+  "utf8",
+);
+assert.match(
+  autoMergeWorkflowSource,
+  /requires human review before merge/,
+  "collect repairs must never be auto-merged",
+);
 
 const reportingSource = fs.readFileSync("scripts/lib/reporting.mjs", "utf8");
 assertNoDuplicateObjectKeys(reportingSource, "vscodeReleaseSummaries");
@@ -119,6 +166,16 @@ assert.match(
   collectSource,
   /if \(renderExistingSummariesOnly\) \{\s*await writeDailySummaries\(logs\);[\s\S]*?return;/,
   "offline summary renderer must return before source collection",
+);
+assert.match(
+  collectSource,
+  /partitionLowInformationEvents\(editorialEvents\)/,
+  "collector must remove low-information reader events before persistence",
+);
+assert.match(
+  collectSource,
+  /skippedLowInformationEvents/,
+  "collector must leave an auditable record of excluded events",
 );
 
 assertCliFails(
@@ -416,6 +473,37 @@ for (const event of unknownSamples) {
   assertLowInformationFallback(localizedSummary(event), event.title);
   assertNoLowInformationFallback(importanceReason(event), event.title);
 }
+const lowInformationEvent = unknownSamples[0];
+const concreteEvent = {
+  title: "Copilot code review: AGENTS.md support and UI improvements",
+  summary:
+    "Copilot code review now supports repository-level AGENTS.md files, and it’s easier to request a review from Copilot on draft pull requests with the Request button.",
+  categories: ["Improvement", "copilot"],
+};
+const auditOnlyLowInformationEvent = {
+  ...lowInformationEvent,
+  kind: "html_snapshot_change",
+  diffSummary: {},
+};
+assert.ok(
+  lowInformationFallbacksForEvent(lowInformationEvent).length > 0,
+  "unknown reader-facing events must expose their fallback markers",
+);
+const lowInformationPartition = partitionLowInformationEvents([
+  lowInformationEvent,
+  concreteEvent,
+  auditOnlyLowInformationEvent,
+]);
+assert.deepEqual(
+  lowInformationPartition.acceptedEvents,
+  [concreteEvent, auditOnlyLowInformationEvent],
+  "low-information reader events must not be persisted while audit-only evidence is retained",
+);
+assert.equal(
+  lowInformationPartition.rejectedEvents.length,
+  1,
+  "low-information reader events must be recorded as rejected",
+);
 assert.doesNotMatch(
   summarizeEventSet(unknownSamples, "ja", { maxHighlights: 3 }),
   /英語 summary では/,


### PR DESCRIPTION
## Root cause

The scheduled collector persisted reader-facing events whose Japanese summary or importance reason was a generic low-information fallback. `npm run test:data` correctly rejected the generated daily event log, so the collect commit and Pages redeploy never ran.

## Recovery

- The collector now partitions events after editorial policy evaluation and excludes reader-facing events that render any shared low-information marker.
- Exclusions are auditable in `latestRun.skippedLowInformationEvents` and the workflow log; audit-only observations remain available.
- The low-information guard remains unchanged, so generic cards cannot be published.

## Bounded self-healing

- A failed `Collect updates` run is routed through the existing authoring Issue / Copilot assignment flow.
- Only the known `Collect updates` and `Validate collected output` failure classes receive an automated, traceable repair PR request.
- Repair PRs can change only the collector/reporting, source selector, and focused tests; `data/**` and quality guards remain protected.
- Metadata normalization preserves repair PR metadata, and every collection-pipeline repair is labelled `needs-human-review` and is never auto-merged.
- Unclassified collect failures create a visible, human-review-only Issue rather than attempting a blind repair.

## Validation

- `npm run collect` (31 source events collected; 21 low-information events excluded before persistence)
- `npm run test:data`
- `npm run build:pages`
- `npm test`
- `node --check scripts/collect.mjs`
- `node --check scripts/lib/reporting.mjs`
- YAML parsing for all changed workflows